### PR TITLE
chore: fix gh-a var name

### DIFF
--- a/.github/workflows/verify-conformance.yaml
+++ b/.github/workflows/verify-conformance.yaml
@@ -12,7 +12,7 @@ jobs:
         run: |
           docker run --rm \
             --workdir /github/workspace \
-            -e GITHUB_TOKEN -e GITHUB_EVENT_FILE=/github/workflow/event.json \
+            -e GITHUB_TOKEN -e GITHUB_EVENT_PATH=/github/workflow/event.json \
             -v "$PWD":"/github/workspace" \
             -v "/home/runner/work/_temp/_github_workflow":"/github/workflow" \
               ghcr.io/cncf-infra/verify-conformance/action:latest


### PR DESCRIPTION
use GITHUB_EVENT_PATH

